### PR TITLE
Remove ssh key templates and rely on terrafomr to populate the keys.

### DIFF
--- a/jenkins/docker/etc/confd/conf.d/id_rsa.toml
+++ b/jenkins/docker/etc/confd/conf.d/id_rsa.toml
@@ -1,9 +1,0 @@
-[template]
-src = "id_rsa.tmpl"
-dest = "/srv/jenkins/.ssh/id_rsa"
-mode = "0600"
-uid = 1000
-keys = [
-  "/jenkins"
-]
-check_cmd = "/bin/echo -e $JENKINS_GITHUB_PRIVKEY > {{.src}}"

--- a/jenkins/docker/etc/confd/conf.d/id_rsa_pub.toml
+++ b/jenkins/docker/etc/confd/conf.d/id_rsa_pub.toml
@@ -1,8 +1,0 @@
-[template]
-src = "id_rsa_pub.tmpl"
-dest = "/srv/jenkins/.ssh/id_rsa.pub"
-mode = "0600"
-uid = 1000
-keys = [
-  "/jenkins"
-]

--- a/jenkins/docker/etc/confd/templates/id_rsa.tmpl
+++ b/jenkins/docker/etc/confd/templates/id_rsa.tmpl
@@ -1,1 +1,0 @@
-{{if exists "/jenkins/github/privkey" }}{{ getv "/jenkins/github/privkey" }}{{end}}

--- a/jenkins/docker/etc/confd/templates/id_rsa_pub.tmpl
+++ b/jenkins/docker/etc/confd/templates/id_rsa_pub.tmpl
@@ -1,1 +1,0 @@
-{{if exists "/jenkins/github/pubkey" }}{{ getv "/jenkins/github/pubkey" }}{{end}}


### PR DESCRIPTION
Remove ssh_id key generation from confd. This is done by terraform.
