### PR TITLE
Added application/javascript to gzip config

### DIFF
--- a/nginx/docker/nginx/nginx.conf
+++ b/nginx/docker/nginx/nginx.conf
@@ -78,7 +78,7 @@ http {
     gzip_proxied any;
     gzip_min_length  1100;
     gzip_buffers 16 8k;
-    gzip_types text/plain text/css application/x-javascript text/xml application/xml application/xml+rss text/javascript; # text/html already included
+    gzip_types text/plain text/css application/x-javascript text/xml application/xml application/xml+rss text/javascript application/javascript; # text/html already included
     # Some version of IE 6 don't handle compression well on some mime-types, so just disable for them
     gzip_disable "MSIE [1-6].(?!.*SV1)";
     # Set a vary header so downstream proxies don't send cached gzipped content to IE6


### PR DESCRIPTION
nginx uses a new mime type for javascript, so files weren't getting
compressed
