### PR TITLE
Opgops 1663

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ ifdef stage
 	stagearg := --stage $(stage)
 endif
 
+ifdef buildArgs
+    no-cache := --no-cache
+endif
+
 currenttag := $(shell semvertag latest $(stagearg))
 newtag := $(shell semvertag bump patch $(stagearg))
 
@@ -26,10 +30,10 @@ else
 endif
 
 $(CORE_CONTAINERS):
-	$(MAKE) -C $@ newtag=$(newtag) registryUrl=$(registryUrl)
+	$(MAKE) -C $@ newtag=$(newtag) registryUrl=$(registryUrl) no-cache=$(no-cache)
 
 $(CHILD_CONTAINERS):
-	$(MAKE) -C $@ newtag=$(newtag) registryUrl=$(registryUrl)
+	$(MAKE) -C $@ newtag=$(newtag) registryUrl=$(registryUrl) no-cache=$(no-cache)
 
 push:
 	for i in $(CORE_CONTAINERS) $(CHILD_CONTAINERS); do \

--- a/Makefile
+++ b/Makefile
@@ -5,26 +5,12 @@ CLEAN_CONTAINERS := $(CORE_CONTAINERS) $(CHILD_CONTAINERS)
 .PHONY: build push pull showinfo test $(CORE_CONTAINERS) $(CHILD_CONTAINERS) clean
 
 tagrepo = no
-ifneq ($(stage),)
-	stagearg = --stage $(stage)
+ifdef stage
+	stagearg := --stage $(stage)
 endif
 
-currenttag = $(shell semvertag latest $(stagearg))
-ifneq ($(findstring ERROR, $(currenttag)),)
-    currenttag = 0.0.0
-    ifneq ($(stage),)
-        currenttag = 0.0.0-$(stage)
-    endif        
-endif        
-
-newtag = $(shell semvertag bump patch $(stagearg))
-ifneq ($(findstring ERROR, $(newtag)),)
-    newtag = 0.0.1
-    ifneq ($(stage),)
-        newtag = 0.0.1-$(stage)
-    endif        
-endif        
-
+currenttag := $(shell semvertag latest $(stagearg))
+newtag := $(shell semvertag bump patch $(stagearg))
 
 registryUrl = registry.service.opg.digital
 oldRegistryUrl = registry.service.dsd.io
@@ -47,12 +33,12 @@ $(CHILD_CONTAINERS):
 
 push:
 	for i in $(CORE_CONTAINERS) $(CHILD_CONTAINERS); do \
-			[ "$(stagearg)x" = "x" ] && docker push $(registryUrl)/opguk/$$i ; \
+			[ "$(tagrepo)" = "yes" ] && docker push $(registryUrl)/opguk/$$i ; \
 			docker push $(registryUrl)/opguk/$$i:$(newtag) ; \
 	done
 	#push to old registry
 	for i in $(CORE_CONTAINERS) $(CHILD_CONTAINERS); do \
-			[ "$(stagearg)x" = "x" ] && docker push $(oldRegistryUrl)/opguk/$$i ; \
+			[ "$(tagrepo)" = "yes" ] && docker push $(oldRegistryUrl)/opguk/$$i ; \
 			docker push $(oldRegistryUrl)/opguk/$$i:$(newtag) ; \
 	done
 
@@ -64,7 +50,6 @@ pull:
 showinfo:
 	@echo Registry: $(registryUrl)
 	@echo Newtag: $(newtag)
-	@echo Stage: $(stagearg)
 	@echo Current Tag: $(currenttag)
 	@echo Core Container List: $(CORE_CONTAINERS)
 	@echo Container List: $(CHILD_CONTAINERS)

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ ifdef stage
 endif
 
 ifdef buildArgs
-    no-cache := --no-cache
+	no-cache := --no-cache
 endif
 
 currenttag := $(shell semvertag latest $(stagearg))
@@ -24,6 +24,7 @@ buildchild: $(CHILD_CONTAINERS)
 
 build: buildcore buildchild
 ifeq ($(tagrepo),yes)
+	@echo -e Tagging repo
 	semvertag tag $(newtag)
 else
 	@echo -e Not tagging repo

--- a/backupninja/Makefile
+++ b/backupninja/Makefile
@@ -6,7 +6,7 @@ oldRegistryUrl ?= registry.service.dsd.io
 image = opguk/backupninja
 
 build:
-	docker build -t "$(registryUrl)/$(image)" .
+	docker build $(no-cache) -t "$(registryUrl)/$(image)" .
 	docker tag -f "$(registryUrl)/$(image)" "$(registryUrl)/$(image):$(newtag)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image):$(newtag)"

--- a/backupninja/docker/etc/backupninja.conf
+++ b/backupninja/docker/etc/backupninja.conf
@@ -55,7 +55,7 @@ admingroup = root
 #######################################################
 
 # where to log:
-logfile = /var/log/backupninja.log
+logfile = /var/log/syslog
 
 # directory where all the backup configuration files live
 configdirectory = /etc/backup.d

--- a/backupninja/docker/etc/logrotate.d/backupninja
+++ b/backupninja/docker/etc/logrotate.d/backupninja
@@ -1,6 +1,0 @@
-/var/log/backupninja.log {
-	rotate 6
-	monthly
-	compress
-	missingok
-}

--- a/backupninja/docker/usr/share/backupninja/mongodb
+++ b/backupninja/docker/usr/share/backupninja/mongodb
@@ -50,7 +50,7 @@ fi
 if [ "$mongouser" -a "$mongopass" ]
 then
 	info "using $mongouser for authentication"
-	AUTH="-u ''$mongouser' -p '$mongopass'"
+	AUTH="-u '$mongouser' -p '$mongopass'"
 fi
 
 if [ -n "$mongodb" ]

--- a/backupninja/docker/usr/share/backupninja/mongodb
+++ b/backupninja/docker/usr/share/backupninja/mongodb
@@ -50,7 +50,7 @@ fi
 if [ "$mongouser" -a "$mongopass" ]
 then
 	info "using $mongouser for authentication"
-	AUTH="-u $mongouser -p $mongopass"
+	AUTH="-u ''$mongouser' -p '$mongopass'"
 fi
 
 if [ -n "$mongodb" ]

--- a/base/Makefile
+++ b/base/Makefile
@@ -6,7 +6,7 @@ oldRegistryUrl ?= registry.service.dsd.io
 image = opguk/base
 
 build:
-	docker build -t "$(registryUrl)/$(image)" .
+	docker build $(no-cache) -t "$(registryUrl)/$(image)" .
 	docker tag -f "$(registryUrl)/$(image)" "$(registryUrl)/$(image):$(newtag)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image):$(newtag)"

--- a/casperjs/Makefile
+++ b/casperjs/Makefile
@@ -6,7 +6,7 @@ oldRegistryUrl ?= registry.service.dsd.io
 image = opguk/casperjs
 
 build:
-	docker build -t "$(registryUrl)/$(image)" .
+	docker build $(no-cache) -t "$(registryUrl)/$(image)" .
 	docker tag -f "$(registryUrl)/$(image)" "$(registryUrl)/$(image):$(newtag)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image):$(newtag)"

--- a/elasticsearch-shared-data/Makefile
+++ b/elasticsearch-shared-data/Makefile
@@ -6,7 +6,7 @@ oldRegistryUrl ?= registry.service.dsd.io
 image = opguk/elasticsearch-shared-data
 
 build:
-	docker build -t "$(registryUrl)/$(image)" .
+	docker build $(no-cache) -t "$(registryUrl)/$(image)" .
 	docker tag -f "$(registryUrl)/$(image)" "$(registryUrl)/$(image):$(newtag)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image):$(newtag)"

--- a/elasticsearch/Makefile
+++ b/elasticsearch/Makefile
@@ -6,7 +6,7 @@ oldRegistryUrl ?= registry.service.dsd.io
 image = opguk/elasticsearch
 
 build:
-	docker build -t "$(registryUrl)/$(image)" .
+	docker build $(no-cache) -t "$(registryUrl)/$(image)" .
 	docker tag -f "$(registryUrl)/$(image)" "$(registryUrl)/$(image):$(newtag)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image):$(newtag)"

--- a/fake-sqs/Makefile
+++ b/fake-sqs/Makefile
@@ -6,7 +6,7 @@ oldRegistryUrl ?= registry.service.dsd.io
 image = opguk/fake-sqs
 
 build:
-	docker build -t "$(registryUrl)/$(image)" .
+	docker build $(no-cache) -t "$(registryUrl)/$(image)" .
 	docker tag -f "$(registryUrl)/$(image)" "$(registryUrl)/$(image):$(newtag)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image):$(newtag)"

--- a/golang/Makefile
+++ b/golang/Makefile
@@ -6,7 +6,7 @@ oldRegistryUrl ?= registry.service.dsd.io
 image = opguk/golang
 
 build:
-	docker build -t "$(registryUrl)/$(image)" .
+	docker build $(no-cache) -t "$(registryUrl)/$(image)" .
 	docker tag -f "$(registryUrl)/$(image)" "$(registryUrl)/$(image):$(newtag)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image):$(newtag)"

--- a/jenkins-slave/Makefile
+++ b/jenkins-slave/Makefile
@@ -6,7 +6,7 @@ oldRegistryUrl ?= registry.service.dsd.io
 image = opguk/jenkins-slave
 
 build:
-	docker build -t "$(registryUrl)/$(image)" .
+	docker build $(no-cache) -t "$(registryUrl)/$(image)" .
 	docker tag -f "$(registryUrl)/$(image)" "$(registryUrl)/$(image):$(newtag)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image):$(newtag)"

--- a/jenkins/Makefile
+++ b/jenkins/Makefile
@@ -6,7 +6,7 @@ oldRegistryUrl ?= registry.service.dsd.io
 image = opguk/jenkins
 
 build:
-	docker build -t "$(registryUrl)/$(image)" .
+	docker build $(no-cache) -t "$(registryUrl)/$(image)" .
 	docker tag -f "$(registryUrl)/$(image)" "$(registryUrl)/$(image):$(newtag)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image):$(newtag)"

--- a/jre-8/Makefile
+++ b/jre-8/Makefile
@@ -6,7 +6,7 @@ oldRegistryUrl ?= registry.service.dsd.io
 image = opguk/jre-8
 
 build:
-	docker build -t "$(registryUrl)/$(image)" .
+	docker build $(no-cache) -t "$(registryUrl)/$(image)" .
 	docker tag -f "$(registryUrl)/$(image)" "$(registryUrl)/$(image):$(newtag)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image):$(newtag)"

--- a/kibana/Makefile
+++ b/kibana/Makefile
@@ -6,7 +6,7 @@ oldRegistryUrl ?= registry.service.dsd.io
 image = opguk/kibana
 
 build:
-	docker build -t "$(registryUrl)/$(image)" .
+	docker build $(no-cache) -t "$(registryUrl)/$(image)" .
 	docker tag -f "$(registryUrl)/$(image)" "$(registryUrl)/$(image):$(newtag)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image):$(newtag)"

--- a/mongodb/Makefile
+++ b/mongodb/Makefile
@@ -6,7 +6,7 @@ oldRegistryUrl ?= registry.service.dsd.io
 image = opguk/mongodb
 
 build:
-	docker build -t "$(registryUrl)/$(image)" .
+	docker build $(no-cache) -t "$(registryUrl)/$(image)" .
 	docker tag -f "$(registryUrl)/$(image)" "$(registryUrl)/$(image):$(newtag)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image):$(newtag)"

--- a/mongodb/docker/confd/templates/backup_mongo.tmpl
+++ b/mongodb/docker/confd/templates/backup_mongo.tmpl
@@ -1,4 +1,4 @@
 when = {{ getv "/backupninja/mongo/when" }}
 mongouser = admin
-mongopass = {{ getv "/mongo/admin/password" }}
+mongopass = "{{ getv "/mongo/admin/password" }}"
 noprimarybackup = {{ getv "/backupninja/mongo/noprimary" }}

--- a/mongodb/docker/confd/templates/backup_mongo.tmpl
+++ b/mongodb/docker/confd/templates/backup_mongo.tmpl
@@ -1,4 +1,4 @@
 when = {{ getv "/backupninja/mongo/when" }}
 mongouser = admin
-mongopass = "{{ getv "/mongo/admin/password" }}"
+mongopass = {{ getv "/mongo/admin/password" }}
 noprimarybackup = {{ getv "/backupninja/mongo/noprimary" }}

--- a/nginx-redirect/Makefile
+++ b/nginx-redirect/Makefile
@@ -6,7 +6,7 @@ oldRegistryUrl ?= registry.service.dsd.io
 image = opguk/nginx-redirect
 
 build:
-	docker build -t "$(registryUrl)/$(image)" .
+	docker build $(no-cache) -t "$(registryUrl)/$(image)" .
 	docker tag -f "$(registryUrl)/$(image)" "$(registryUrl)/$(image):$(newtag)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image):$(newtag)"

--- a/nginx-router/Makefile
+++ b/nginx-router/Makefile
@@ -6,7 +6,7 @@ oldRegistryUrl ?= registry.service.dsd.io
 image = opguk/nginx-router
 
 build:
-	docker build -t "$(registryUrl)/$(image)" .
+	docker build $(no-cache) -t "$(registryUrl)/$(image)" .
 	docker tag -f "$(registryUrl)/$(image)" "$(registryUrl)/$(image):$(newtag)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image):$(newtag)"

--- a/nginx/Makefile
+++ b/nginx/Makefile
@@ -6,7 +6,7 @@ oldRegistryUrl ?= registry.service.dsd.io
 image = opguk/nginx
 
 build:
-	docker build -t "$(registryUrl)/$(image)" .
+	docker build $(no-cache) -t "$(registryUrl)/$(image)" .
 	docker tag -f "$(registryUrl)/$(image)" "$(registryUrl)/$(image):$(newtag)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image):$(newtag)"

--- a/php-fpm/Makefile
+++ b/php-fpm/Makefile
@@ -6,7 +6,7 @@ oldRegistryUrl ?= registry.service.dsd.io
 image = opguk/php-fpm
 
 build:
-	docker build -t "$(registryUrl)/$(image)" .
+	docker build $(no-cache) -t "$(registryUrl)/$(image)" .
 	docker tag -f "$(registryUrl)/$(image)" "$(registryUrl)/$(image):$(newtag)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image):$(newtag)"

--- a/rabbitmq/Dockerfile
+++ b/rabbitmq/Dockerfile
@@ -3,21 +3,11 @@ FROM registry.service.opg.digital/opguk/base
 # add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
 RUN groupadd -r rabbitmq && useradd -r -d /var/lib/rabbitmq -m -g rabbitmq rabbitmq
 
-RUN apt-get update && apt-get install -y curl ca-certificates --no-install-recommends && rm -rf /var/lib/apt/lists/*
-
-# grab gosu for easy step-down from root
-RUN gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
-RUN curl -o /usr/local/bin/gosu -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$(dpkg --print-architecture)" \
-	&& curl -o /usr/local/bin/gosu.asc -SL "https://github.com/tianon/gosu/releases/download/1.3/gosu-$(dpkg --print-architecture).asc" \
-	&& gpg --verify /usr/local/bin/gosu.asc \
-	&& rm /usr/local/bin/gosu.asc \
-	&& chmod +x /usr/local/bin/gosu
-
 # Add the officially endorsed Erlang debian repository:
 # See:
 #  - http://www.erlang.org/download.html
 #  - https://www.erlang-solutions.com/downloads/download-erlang-otp
-RUN apt-key adv --keyserver ha.pool.sks-keyservers.net --recv-keys 434975BD900CCBE4F7EE1B1ED208507CA14F4FCA
+RUN wget -O- https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | apt-key add -
 RUN echo 'deb http://packages.erlang-solutions.com/debian wheezy contrib' > /etc/apt/sources.list.d/erlang.list
 
 # get logs to stdout (thanks @dumbbell for pushing this upstream! :D)

--- a/rabbitmq/Makefile
+++ b/rabbitmq/Makefile
@@ -6,7 +6,7 @@ oldRegistryUrl ?= registry.service.dsd.io
 image = opguk/rabbitmq
 
 build:
-	docker build -t "$(registryUrl)/$(image)" .
+	docker build $(no-cache) -t "$(registryUrl)/$(image)" .
 	docker tag -f "$(registryUrl)/$(image)" "$(registryUrl)/$(image):$(newtag)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image):$(newtag)"

--- a/salt-master/Makefile
+++ b/salt-master/Makefile
@@ -6,7 +6,7 @@ oldRegistryUrl ?= registry.service.dsd.io
 image = opguk/salt-master
 
 build:
-	docker build -t "$(registryUrl)/$(image)" .
+	docker build $(no-cache) -t "$(registryUrl)/$(image)" .
 	docker tag -f "$(registryUrl)/$(image)" "$(registryUrl)/$(image):$(newtag)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image):$(newtag)"

--- a/wkhtmlpdf/Makefile
+++ b/wkhtmlpdf/Makefile
@@ -6,7 +6,7 @@ oldRegistryUrl ?= registry.service.dsd.io
 image = opguk/wkhtmlpdf
 
 build:
-	docker build -t "$(registryUrl)/$(image)" .
+	docker build $(no-cache) -t "$(registryUrl)/$(image)" .
 	docker tag -f "$(registryUrl)/$(image)" "$(registryUrl)/$(image):$(newtag)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image):$(newtag)"

--- a/wordpress/Makefile
+++ b/wordpress/Makefile
@@ -6,7 +6,7 @@ oldRegistryUrl ?= registry.service.dsd.io
 image = opguk/wordpress
 
 build:
-	docker build -t "$(registryUrl)/$(image)" .
+	docker build $(no-cache) -t "$(registryUrl)/$(image)" .
 	docker tag -f "$(registryUrl)/$(image)" "$(registryUrl)/$(image):$(newtag)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image)"
 	docker tag -f "$(registryUrl)/$(image)" "$(oldRegistryUrl)/$(image):$(newtag)"


### PR DESCRIPTION
 * Backup ninja now consumes special chars in passwords
 * Backupninja logs to syslog so that ELK can consume the logs
 * Removed custom logging config
 * Makefile allows for the --no-cache argument to pass through
 * GOSU version in kibana standardised with other GOSU versions
```
root@instanceid:/# env | grep admin
MONGO_USER=db|user|a/6S!f$|readAnyDatabase

Dec 21 14:23:58 Info: >>>> starting action /etc/backup.d/30.mongodb (because 'when = hourly')
Dec 21 14:23:58 Info: using <db> for authentication
Dec 21 14:23:58 Info: Successfully removed old dump (if exist)
Dec 21 14:23:58 Info: Successfully finished dump of all mongodb databases
Dec 21 14:23:58 Info: <<<< finished action /etc/backup.d/30.mongodb: SUCCESS
```
