### PR TITLE
DAPH-167: base: bump beaver queue size to remove the ERROR queue full messages

### DIFF
--- a/base/docker/beaver.conf
+++ b/base/docker/beaver.conf
@@ -3,6 +3,7 @@ redis_url: redis://monitoring:6379/0
 redis_namespace: logstash
 logstash_version: 1
 queue_timeout: 3600
+max_queue_size: 10000
 
 [/var/log/ebs-snapshot.log]
 format: json


### PR DESCRIPTION
See: https://opgtransform.atlassian.net/browse/DAPH-167?filter=19100

and

See: https://github.com/python-beaver/python-beaver/issues/342


green build: https://jenkins.service.opg.digital/job/OPG/job/docker-build-base/261/console