### PR TITLE
Opgops 2253 parallise docker builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,14 +32,19 @@ endif
 registryUrl = registry.service.opg.digital
 
 
+
 buildcore: $(CORE_CONTAINERS)
 buildchild: $(CHILD_CONTAINERS)
 
 
-build: 
+paralell_build: 
 	python build.py $(CORE_CONTAINERS)
 	python build.py $(CHILD_CONTAINERS)
 
+
+make_build: buildcore buildchild
+
+build: paralell_build make_build
 
 $(CORE_CONTAINERS):
 	$(MAKE) -C $@ newtag=$(newtag) registryUrl=$(registryUrl) no-cache=$(no-cache)

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,10 @@ endif
 registryUrl = registry.service.opg.digital
 
 
+buildcore: $(CORE_CONTAINERS)
+buildchild: $(CHILD_CONTAINERS)
+
+
 build: 
 	python build.py $(CORE_CONTAINERS)
 	python build.py $(CHILD_CONTAINERS)
@@ -80,4 +84,4 @@ clean:
 		docker rmi $(registryUrl)/opguk/$$i || true ; \
 	done
 
-all: showinfo build push clean
+all: showinfo build buildcore buildchild push clean

--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ endif
 
 registryUrl = registry.service.opg.digital
 
-buildcore: $(CORE_CONTAINERS)
-buildchild: $(CHILD_CONTAINERS)
 
-build: buildcore buildchild
+build: 
+	python build.py $(CORE_CONTAINERS)
+	python build.py $(CHILD_CONTAINERS)
 
 
 $(CORE_CONTAINERS):

--- a/build.py
+++ b/build.py
@@ -1,0 +1,96 @@
+from multiprocessing import Pool
+from time import sleep
+from datetime import datetime
+import os
+import sys
+from functools import partial
+
+import subprocess
+
+def docker_build(docker_img, _):
+    cmd = ['docker',
+           'build',
+           '-t',
+           docker_img,
+           '.']
+
+    start = datetime.now()
+    pipes = subprocess.Popen(cmd,
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE,
+                             cwd=docker_img,
+                             shell=False)
+
+    std_out, std_err = pipes.communicate()
+    end = datetime.now()
+
+    duration = end - start
+
+    # add time it took to build this image
+    return (docker_img, pipes.returncode, std_out, std_err, start, end, duration)
+
+
+
+def build_batch_of_docker_images(image_list, concurrency):
+    pool = Pool(processes=concurrency)
+
+    results = []
+
+    for build in image_list:
+        results.append(pool.map_async(partial(docker_build, build), [1]))
+
+    pool.close()
+    pool.join()
+
+    print_build_results(results)
+    retry_failed_jobs(results)
+
+    return results
+
+
+def print_build_results(results, detail=False):
+    for result in results:
+
+        image, rc, stdout, stderr, start, end, duration  =  result.get()[0]
+        print "build job for %s started at %s and took %s terminating with an exit code %s" % (image, start, duration, rc )
+        if detail:
+            print "stdout for job %s:" % image
+            print stdout
+            print "stderr for job %s:" % image
+            print stderr
+
+
+
+def retry_failed_jobs(results):
+# retry any failures here
+    for result in results:
+        image, rc, stdout, stderr, start, end, duration  =  result.get()[0]
+
+        if rc != 0:
+            print "retrying failed job %s" % image
+            docker_build(image, False)
+            print_build_results([ result ], detail=False)
+
+
+def measure_overall_sucess(results):
+    failures = 0
+
+    for result in results:
+        image, rc, stdout, stderr, start, end, duration  =  result.get()[0]
+
+        if rc != 0:
+            failures = failures + 1
+            print_build_results([ result ], detail=True)
+    return failures
+
+
+
+# build the batch and abort on any build failure
+
+batch = sys.argv[1:]
+print "starting build.py with params: %s" % batch
+
+results = build_batch_of_docker_images(batch, len(batch))
+if measure_overall_sucess(results) != 0:
+    sys.exit(1)
+

--- a/build.py
+++ b/build.py
@@ -8,11 +8,7 @@ from functools import partial
 import subprocess
 
 def docker_build(docker_img, _):
-    cmd = ['docker',
-           'build',
-           '-t',
-           docker_img,
-           '.']
+    cmd = ['make']
 
     start = datetime.now()
     pipes = subprocess.Popen(cmd,
@@ -90,7 +86,8 @@ def measure_overall_sucess(results):
 batch = sys.argv[1:]
 print "starting build.py with params: %s" % batch
 
-results = build_batch_of_docker_images(batch, len(batch))
+# build a maximum of 8 containers in parallel
+results = build_batch_of_docker_images(batch, 8)
 if measure_overall_sucess(results) != 0:
     sys.exit(1)
 


### PR DESCRIPTION
dump of the changes already done on the sirius-builds,

looking at : https://jenkins.service.opg.digital/job/OPG/view/docker/job/docker-build-base/315/

this seems to cut about 15 minutes from the build time.

